### PR TITLE
Add 2 scripts for testing libraries. Change suites to prevent error in some libraries.

### DIFF
--- a/src/cz/crcs/ectester/standalone/test/suites/StandaloneCofactorSuite.java
+++ b/src/cz/crcs/ectester/standalone/test/suites/StandaloneCofactorSuite.java
@@ -90,11 +90,10 @@ public class StandaloneCofactorSuite extends StandaloneTestSuite {
             List<Test> allKaTests = new LinkedList<>();
             for (KeyAgreementIdent kaIdent : cfg.selected.getKAs()) {
                 if (kaAlgo == null || kaIdent.containsAny(kaTypes)) {
-                    KeyAgreement ka = kaIdent.getInstance(cfg.selected.getProvider());
-
                     List<Test> specificKaTests = new LinkedList<>();
                     for (EC_Key.Public pub : keys) {
                         ECPublicKey ecpub = ECUtil.toPublicKey(pub);
+                        KeyAgreement ka = kaIdent.getInstance(cfg.selected.getProvider());
                         KeyAgreementTestable testable = new KeyAgreementTestable(ka, ecpriv, ecpub);
                         Test keyAgreement = KeyAgreementTest.expectError(testable, Result.ExpectedValue.FAILURE);
                         specificKaTests.add(CompoundTest.all(Result.ExpectedValue.SUCCESS, pub.getId() + " cofactor key test.", keyAgreement));

--- a/src/cz/crcs/ectester/standalone/test/suites/StandaloneCompositeSuite.java
+++ b/src/cz/crcs/ectester/standalone/test/suites/StandaloneCompositeSuite.java
@@ -100,11 +100,10 @@ public class StandaloneCompositeSuite extends StandaloneTestSuite {
             List<Test> allKaTests = new LinkedList<>();
             for (KeyAgreementIdent kaIdent : cfg.selected.getKAs()) {
                 if (kaAlgo == null || kaIdent.containsAny(kaTypes)) {
-                    KeyAgreement ka = kaIdent.getInstance(cfg.selected.getProvider());
-
                     List<Test> specificKaTests = new LinkedList<>();
                     for (EC_Key.Public pub : curveKeys.getValue()) {
                         ECPublicKey ecpub = ECUtil.toPublicKey(pub);
+                        KeyAgreement ka = kaIdent.getInstance(cfg.selected.getProvider());
                         KeyAgreementTestable testable = new KeyAgreementTestable(ka, ecpriv ,ecpub);
                         Test keyAgreement = KeyAgreementTest.expectError(testable, Result.ExpectedValue.FAILURE);
                         specificKaTests.add(CompoundTest.all(Result.ExpectedValue.SUCCESS, "Composite test of " + curve.getId() + ", with generated private key, " + pub.getDesc(), keyAgreement));

--- a/src/cz/crcs/ectester/standalone/test/suites/StandaloneDegenerateSuite.java
+++ b/src/cz/crcs/ectester/standalone/test/suites/StandaloneDegenerateSuite.java
@@ -90,11 +90,10 @@ public class StandaloneDegenerateSuite extends StandaloneTestSuite {
             List<Test> allKaTests = new LinkedList<>();
             for (KeyAgreementIdent kaIdent : cfg.selected.getKAs()) {
                 if (kaAlgo == null || kaIdent.containsAny(kaTypes)) {
-                    KeyAgreement ka = kaIdent.getInstance(cfg.selected.getProvider());
-
                     List<Test> specificKaTests = new LinkedList<>();
                     for (EC_Key.Public pub : keys) {
                         ECPublicKey ecpub = ECUtil.toPublicKey(pub);
+                        KeyAgreement ka = kaIdent.getInstance(cfg.selected.getProvider());
                         KeyAgreementTestable testable = new KeyAgreementTestable(ka, ecpriv, ecpub);
                         Test keyAgreement = KeyAgreementTest.expectError(testable, Result.ExpectedValue.FAILURE);
                         specificKaTests.add(CompoundTest.all(Result.ExpectedValue.SUCCESS, pub.getId() + " degenerate key test.", keyAgreement));

--- a/src/cz/crcs/ectester/standalone/test/suites/StandaloneInvalidSuite.java
+++ b/src/cz/crcs/ectester/standalone/test/suites/StandaloneInvalidSuite.java
@@ -89,11 +89,10 @@ public class StandaloneInvalidSuite extends StandaloneTestSuite {
             List<Test> allKaTests = new LinkedList<>();
             for (KeyAgreementIdent kaIdent : cfg.selected.getKAs()) {
                 if (kaAlgo == null || kaIdent.containsAny(kaTypes)) {
-                    KeyAgreement ka = kaIdent.getInstance(cfg.selected.getProvider());
-
                     List<Test> specificKaTests = new LinkedList<>();
                     for (EC_Key.Public pub : keys) {
                         ECPublicKey ecpub = ECUtil.toPublicKey(pub);
+                        KeyAgreement ka = kaIdent.getInstance(cfg.selected.getProvider());
                         KeyAgreementTestable testable = new KeyAgreementTestable(ka, ecpriv, ecpub);
                         Test keyAgreement = KeyAgreementTest.expectError(testable, Result.ExpectedValue.FAILURE);
                         specificKaTests.add(CompoundTest.all(Result.ExpectedValue.SUCCESS, pub.getId() + " invalid key test.", keyAgreement));

--- a/src/cz/crcs/ectester/standalone/test/suites/StandaloneTwistSuite.java
+++ b/src/cz/crcs/ectester/standalone/test/suites/StandaloneTwistSuite.java
@@ -89,11 +89,10 @@ public class StandaloneTwistSuite extends StandaloneTestSuite {
             List<Test> allKaTests = new LinkedList<>();
             for (KeyAgreementIdent kaIdent : cfg.selected.getKAs()) {
                 if (kaAlgo == null || kaIdent.containsAny(kaTypes)) {
-                    KeyAgreement ka = kaIdent.getInstance(cfg.selected.getProvider());
-
                     List<Test> specificKaTests = new LinkedList<>();
                     for (EC_Key.Public pub : keys) {
                         ECPublicKey ecpub = ECUtil.toPublicKey(pub);
+                        KeyAgreement ka = kaIdent.getInstance(cfg.selected.getProvider());
                         KeyAgreementTestable testable = new KeyAgreementTestable(ka, ecpriv, ecpub);
                         Test keyAgreement = KeyAgreementTest.expectError(testable, Result.ExpectedValue.FAILURE);
                         specificKaTests.add(CompoundTest.all(Result.ExpectedValue.SUCCESS, pub.getId() + " twist key test.", keyAgreement));

--- a/util/run_all_suites.sh
+++ b/util/run_all_suites.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/bash
+#
+# ECTesterStandalone testing script,
+# runs all the suites on all the libraries
+#
+tempfolder=.temp_results
+cur=$PWD
+cd "$(dirname "${BASH_SOURCE[0]}")"/../dist
+run="$(which java) -jar ECTesterStandalone-dist.jar"
+suites=$($run list-suites | grep -P "^ -" | cut -c3-)
+cd $cur
+
+rm -rf $tempfolder
+mkdir $tempfolder
+while read -r suite; do
+    echo "**Run $suite suite on all the libraries:"
+    bash run_test_suite.sh $suite
+    mkdir $tempfolder/$suite
+    unzip results_$suite.zip -d $tempfolder/$suite
+    rm results_$suite.zip
+done <<< "$suites"
+
+if [[ -f results_all.zip ]]; then
+    echo '**Removing old archive...'
+    rm -f results_all.zip
+fi
+echo '**Creating archive...'
+cd $tempfolder && zip -r ../results_all.zip . && cd ..
+rm -rf $tempfolder
+echo "**All tests finished! The results can be found in results_all.zip"

--- a/util/run_test_suite.sh
+++ b/util/run_test_suite.sh
@@ -50,6 +50,9 @@ while read -r lib; do
                 echo "# NOTE: Tests timeouted at this point after taking longer than ${timeout}s." >> $filename
                 echo "#" >> $filename
         fi
+    #Signature suite requires SHA1withECDSA signature type
+    elif [[ $suite == "signature" ]]; then
+        $run test $args -st SHA1withECDSA $suite "$lib" > $tempfolder/$"${lib// /_}"-${suite}_suite-results.txt 2>&1
     else
         $run test $args $suite "$lib" > $tempfolder/$"${lib// /_}"-${suite}_suite-results.txt 2>&1
     fi

--- a/util/run_test_suite.sh
+++ b/util/run_test_suite.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/bash
+#
+# ECTesterStandalone testing script,
+# runs the specified suite on all installed libraries
+#
+suite=${1,,}
+tempfolder=.temp_results
+cur=$PWD
+timeout=10
+
+cd "$(dirname "${BASH_SOURCE[0]}")"/../dist
+if [[ $# -eq 0 ]]; then
+    echo 'No test suite specified.'
+    exit 0
+fi
+if [[ ! -f ECTesterStandalone-dist.jar ]]; then
+    echo 'ECTesterStandalone-dist.jar not found. Build ECTesterStandalone first.'
+    exit 0
+fi
+
+rm -rf $tempfolder
+mkdir $tempfolder
+run="$(which java) -jar ECTesterStandalone-dist.jar"
+libs=$($run list-libs | grep -P "^\t-" | cut -d"-" -f 2 | cut -d"(" -f1)
+while read -r lib; do
+    echo "Testing library: $lib..."
+    filename=$tempfolder/$"${lib// /_}"-${suite}_suite-results.txt
+
+    #Botan and Crypto++ don't recognize default kgt type EC, specify kgt=ECDH instead.
+    if [[ $lib == *"Botan"* ]] || [[ $lib == *"Crypto++"* ]]; then
+        args="-gt ECDH"
+    else
+        args=""
+    fi
+
+    #Wrong suite can cause a freeze in some libraries. Try running the tests again with the -skip argument if it happens. Default timeout is 10s.
+    if [[ $suite == "wrong" ]]; then
+        timeout ${timeout}s $run test $args $suite "$lib" > $filename 2>&1
+        if [[ $? -eq 124 ]]; then
+                echo "#" >> $filename
+                echo "# NOTE: Tests timeouted at this point after taking longer than ${timeout}s. What follows next is a second run with -skip argument." >> $filename
+                echo "#" >> $filename
+                $run test $args $suite -skip "$lib" >> $filename 2>&1
+        fi
+    #Composite suite can also cause a freeze, but this time there is no -skip argument.
+    elif [[ $suite == "composite" ]]; then
+        timeout ${timeout}s $run test $args $suite "$lib" > $filename 2>&1
+        if [[ $? -eq 124 ]]; then
+                echo "#" >> $filename
+                echo "# NOTE: Tests timeouted at this point after taking longer than ${timeout}s." >> $filename
+                echo "#" >> $filename
+        fi
+    else
+        $run test $args $suite "$lib" > $tempfolder/$"${lib// /_}"-${suite}_suite-results.txt 2>&1
+    fi
+done <<< "$libs"
+
+#Comment out these two lines to keep java error logs. They are removed by default to prevent unnecessary cluttering of dist folder.
+echo 'Removing java error logs...'
+find . -type f -name 'hs_err_*' -exec rm {} \;
+
+if [[ -f $cur/results_$suite.zip ]]; then
+    echo 'Removing old archive...'
+    rm -f $cur/results_$suite.zip
+fi
+echo 'Creating archive...'
+zip -r -j $cur/results_$suite.zip $tempfolder/
+rm -rf $tempfolder
+
+echo "Finished. The results can be found in results_$suite.zip."
+exit 1


### PR DESCRIPTION
Performing multiple KeyAgreement tests on the same KeyAgreement object was causing "Phase already executed" error in some libraries. This should now be fixed.