### PR TITLE
Fallback to HOME enviromental var

### DIFF
--- a/common/src/main/java/cz/crcs/ectester/common/util/FileUtil.java
+++ b/common/src/main/java/cz/crcs/ectester/common/util/FileUtil.java
@@ -44,14 +44,18 @@ public class FileUtil {
 
         if (System.getProperty("os.name").startsWith("Windows")) {
             appData = Paths.get(System.getenv("AppData"));
+            return appData;
         } else {
             if (System.getProperty("os.name").startsWith("Linux")) {
                 String dataHome = System.getenv("XDG_DATA_HOME");
                 if (dataHome != null) {
                     appData = Paths.get(dataHome);
-                } else {
-                    appData = Paths.get(System.getenv("HOME"), ".local", "share");
+                    return appData;
                 }
+            }
+            String userHome = System.getProperty("user.home");
+            if (userHome != null && !userHome.equals("?")) {
+                appData = Paths.get(userHome, ".local", "share");
             } else {
                 appData = Paths.get(System.getenv("HOME"), ".local", "share");
             }

--- a/common/src/main/java/cz/crcs/ectester/common/util/FileUtil.java
+++ b/common/src/main/java/cz/crcs/ectester/common/util/FileUtil.java
@@ -50,10 +50,10 @@ public class FileUtil {
                 if (dataHome != null) {
                     appData = Paths.get(dataHome);
                 } else {
-                    appData = Paths.get(System.getProperty("user.home"), ".local", "share");
+                    appData = Paths.get(System.getenv("HOME"), ".local", "share");
                 }
             } else {
-                appData = Paths.get(System.getProperty("user.home"), ".local", "share");
+                appData = Paths.get(System.getenv("HOME"), ".local", "share");
             }
         }
         return appData;


### PR DESCRIPTION
Getting the correct path for the data directory does not across other machines. When I printed the following:
```
System.getProperty("user.name")
System.getenv("AppData")
System.getenv("XDG_DATA_HOME")
System.getenv("HOME")
```
I got different resuls on different machines:
```
# Machine A
<username>
null
null
/home/<username>
# Machine B
?    # <--- yes, literal question mark
null
null
/home/<username>
```
Maybe we can fallback to `System.getenv("HOME")` then as in the commit. Could be related to [this issue](https://stackoverflow.com/questions/1503284/java-system-getpropertyuser-home-returns).