### PR TITLE
fix applet305 AID in gradle build script

### DIFF
--- a/applet/build.gradle.kts
+++ b/applet/build.gradle.kts
@@ -126,7 +126,7 @@ javacard {
 
                 applet {
                     className("cz.crcs.ectester.applet.ECTesterAppletExtended")
-                    aid("454354657374657230333320323035")
+                    aid("454354657374657230333320333035")
                 }
             }
         }


### PR DESCRIPTION
The AID of the 305 cap file created in `applet/build.gradle.kts` differs from the AID used to select the applet in `ECTesterReader` (See `ECTesterReader.SELECT_PREFIX` and `ECTesterReader.SELECT_SUFFIX`). This PR sets the AID created in `applet/build.gradle.kts` to the one used in `ECTesterReader`.