### PR TITLE
fix variable naming: rename select response for 305 CAP version from …

### DIFF
--- a/reader/src/main/java/cz/crcs/ectester/reader/ECTesterReader.java
+++ b/reader/src/main/java/cz/crcs/ectester/reader/ECTesterReader.java
@@ -151,9 +151,9 @@ public class ECTesterReader {
                 byte[] versionByte = AID_CURRENT_VERSION.clone();
                 boolean selected = false;
                 for (int i = 0; i < TRY_VERSIONS; ++i) {
-                    // Try 301 CAP version
-                    byte[] select301 = ByteUtil.concatenate(SELECT_PREFIX, AID_PREFIX, versionByte, AID_SUFFIX_305);
-                    ResponseAPDU selectResp = cardManager.send(select301);
+                    // Try 305 CAP version
+                    byte[] select305 = ByteUtil.concatenate(SELECT_PREFIX, AID_PREFIX, versionByte, AID_SUFFIX_305);
+                    ResponseAPDU selectResp = cardManager.send(select305);
                     if ((short) selectResp.getSW() != CardUtil.ISO7816.SW_NO_ERROR) {
                         // Try 222 CAP version
                         byte[] select222 = ByteUtil.concatenate(SELECT_PREFIX, AID_PREFIX, versionByte, AID_SUFFIX_222);


### PR DESCRIPTION
Rename the `byte` array for selecting the applet with version 305 from `select301` to `select305`